### PR TITLE
Revert #8 fixing parent id foreign key

### DIFF
--- a/src/Services/Actions/Delete.php
+++ b/src/Services/Actions/Delete.php
@@ -29,13 +29,8 @@ class Delete extends Actions
         DB::beginTransaction();
 
         try {
-            if ($this->model->children()->exists()) {
-                foreach ($this->model->children()->select('id', 'directory', 'external')->get() as $child) {
-                    (new self($child))->run();
-                }
-            }
             $this->model->delete();
-            if (!$this->model->isExternal() and alicia_storage()->exists($this->model->directory)) {
+            if ($this->model->isNotExternal() and alicia_storage()->exists($this->model->directory)) {
                 alicia_storage()->deleteDirectory($this->model->directory);
             }
         } catch (Throwable $e) {

--- a/tests/Unit/ResourceModelTest.php
+++ b/tests/Unit/ResourceModelTest.php
@@ -289,13 +289,12 @@ class ResourceModelTest extends TestCase
         self::assertFalse($model->isExternal());
     }
 
-
     /**
      * @test
      *
-     * @return void
      * @throws InvalidManipulation
      *
+     * @return void
      */
     public function childrenWIllBeDeleted(): void
     {


### PR DESCRIPTION
The children of a parent will be removed through foreign key. meanwhile the associated file with each child will be removed with the parent removal action cause the children associated files stored in the same directory as the parent;